### PR TITLE
Add missingness map and enhanced quality checks

### DIFF
--- a/tests/test_missingness.py
+++ b/tests/test_missingness.py
@@ -8,6 +8,7 @@ class DummyViz(BigQueryVisualizer):
     def __init__(self, df):
         self.full_table_path = 'x'
         self.columns = list(df.columns)
+        self.numeric_columns = []
         self._df = df
     def _execute_query(self, q, use_cache=True):
         return self._df.copy()
@@ -25,3 +26,7 @@ def test_missingness_functions():
 
     combos = viz.frequent_missing_patterns(top_n=2)
     assert len(combos) == 2
+
+    mask, fig, mcar = viz.missingness_map()
+    assert mask.shape == df.shape
+    assert not mcar.empty

--- a/tests/test_quality_stage.py
+++ b/tests/test_quality_stage.py
@@ -2,6 +2,8 @@ import os, sys
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 import pandas as pd
+import seaborn as sns
+import matplotlib.pyplot as plt
 from analysis_context import AnalysisContext
 from stages.core_stages import QualityStage
 
@@ -16,11 +18,23 @@ class DummyViz:
             return pd.DataFrame({'total':[100], 'distinct_rows':[95]})
         if 'COUNT(DISTINCT' in q and 'uniq_' in q:
             return pd.DataFrame({'total':[100], 'uniq_a':[3], 'uniq_num1':[90], 'uniq_cat1':[2]})
+        if 'n_out_z' in q or 'n_out_iqr' in q:
+            return pd.DataFrame({'q1':[0],'q3':[1],'mean':[0.5],'sd':[1],'n':[100],'n_out_iqr':[5],'n_out_z':[4]})
         if 'APPROX_QUANTILES' in q:
             return pd.DataFrame({'q1':[0],'q3':[1],'n':[100],'n_out':[5]})
         if 'GROUP BY cat1' in q:
-            return pd.DataFrame({'cat1':['x','y'], 'n':[98,2]})
+            return pd.DataFrame({'cat1':['x','y','X'], 'n':[97,2,1]})
+        if 'TABLESAMPLE' in q:
+            return pd.DataFrame({'num1':[1,2,3,100]})
         return pd.DataFrame()
+
+    def missingness_map(self, columns=None, sample_rows=100000):
+        df = pd.DataFrame({'a':[1,2], 'num1':[1,2], 'cat1':['x','y']})
+        mask = df.isna()
+        fig, ax = plt.subplots()
+        sns.heatmap(mask.T, cbar=False, ax=ax)
+        mcar = pd.DataFrame({'column': self.columns, 'MCAR': [True]*len(self.columns)})
+        return mask, ax, mcar
 
 
 def test_quality_stage():
@@ -37,3 +51,16 @@ def test_quality_stage():
 
     catq = ctx.get_table('quality.categorical_quality')
     assert not catq.empty
+
+    out = ctx.get_table('quality.outlier_pct')
+    assert 'zscore_outlier_pct' in out.columns
+
+    iso = ctx.get_table('quality.outlier_flags')
+    assert iso is not None
+
+    inc = ctx.get_table('quality.cat1.inconsistent_groups')
+    assert not inc.empty
+
+    assert 'quality.missing_map' in ctx.figures
+    mcar = ctx.get_table('quality.mcar_results')
+    assert not mcar.empty


### PR DESCRIPTION
## Summary
- add `missingness_map` helper with MCAR/MAR tests
- detect inconsistent categorical values in `QualityStage`
- extend outlier detection with z-scores and IsolationForest
- store new results in the context
- expand tests for new functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68795e0802188321a545829724d8dc15