### PR TITLE
Add KDE overlay and stats

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ seaborn
 statsmodels
 scikit-learn
 numpy
+jinja2

--- a/tests/test_histogram_kde.py
+++ b/tests/test_histogram_kde.py
@@ -1,0 +1,22 @@
+import os, sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import pandas as pd
+from bigquery_visualizer import BigQueryVisualizer
+
+class DummyViz(BigQueryVisualizer):
+    def __init__(self, df):
+        self.full_table_path = 'x'
+        self.columns = list(df.columns)
+        self.numeric_columns = ['num']
+        self.categorical_columns = []
+        self._df = df
+    def _execute_query(self, q, use_cache=True):
+        return self._df.copy()
+
+def test_histogram_with_kde():
+    df = pd.DataFrame({'num':[1,2,2,3,4,5]})
+    viz = DummyViz(df)
+    _, fig = viz.plot_histogram(numeric_column='num', kde=True, bins=5)
+    assert fig is not None
+    assert len(fig.data) > 1

--- a/tests/test_numeric_stats.py
+++ b/tests/test_numeric_stats.py
@@ -1,0 +1,27 @@
+import os, sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import pandas as pd
+from bigquery_visualizer import BigQueryVisualizer
+
+class DummyViz(BigQueryVisualizer):
+    def __init__(self):
+        self.full_table_path = 'x'
+        self.numeric_columns = ['num']
+        self.columns = ['num']
+        self.categorical_columns = []
+    def _execute_query(self, q, use_cache=True):
+        if 'VAR_SAMP(num)' in q:
+            return pd.DataFrame({
+                'total_rows':[4],'null_count':[0],'non_null_count':[4],
+                'mean':[2.5],'std_dev':[1.12],'variance':[1.25],'min':[1],'max':[4],
+                'skewness':[0.0],'kurtosis':[1.5],'quartiles':[[1,1.75,2.5,3.25,4]]})
+        return pd.DataFrame({'num':[1,2,3,4]})
+
+def test_numeric_summary_has_skew_kurt():
+    viz = DummyViz()
+    summary = viz.analyze_numeric_column('num')
+    assert 'Skewness' in summary
+    assert 'Kurtosis' in summary
+    df = viz.analyze_all_numeric().data
+    assert 'Skewness' in df.columns

--- a/tests/test_univariate_stage.py
+++ b/tests/test_univariate_stage.py
@@ -1,0 +1,44 @@
+import os, sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import pandas as pd
+from analysis_context import AnalysisContext
+from stages.core_stages import UnivariateStage
+from bigquery_visualizer import BigQueryVisualizer
+
+class DummyViz(BigQueryVisualizer):
+    def __init__(self):
+        self.full_table_path = 'x'
+        self.numeric_columns = ['num1', 'num2']
+        self.columns = self.numeric_columns
+        self.categorical_columns = []
+    def _execute_query(self, q, use_cache=True):
+        if 'VAR_SAMP(num1)' in q:
+            return pd.DataFrame({
+                'total_rows':[4],'null_count':[0],'non_null_count':[4],
+                'mean':[2.5],'std_dev':[1.12],'variance':[1.25],'min':[1],'max':[4],
+                'skewness':[0.0],'kurtosis':[1.5],'quartiles':[[1,1.75,2.5,3.25,4]]})
+        if 'VAR_SAMP(num2)' in q:
+            return pd.DataFrame({
+                'total_rows':[4],'null_count':[0],'non_null_count':[4],
+                'mean':[25],'std_dev':[11.2],'variance':[125.0],'min':[10],'max':[40],
+                'skewness':[0.0],'kurtosis':[1.5],'quartiles':[[10,17.5,25,32.5,40]]})
+        if 'SELECT num1' in q:
+            return pd.DataFrame({'num1':[1,2,3,4]})
+        if 'SELECT num2' in q:
+            return pd.DataFrame({'num2':[10,20,30,40]})
+        return pd.DataFrame()
+
+
+def test_univariate_stage_kde_histograms():
+    ctx = AnalysisContext()
+    viz = DummyViz()
+    UnivariateStage().run(viz, ctx)
+
+    stats = ctx.get_table('univariate.numeric_stats')
+    assert 'Skewness' in stats.columns
+    assert len([k for k in ctx.figures if k.endswith('.hist')]) == len(viz.numeric_columns)
+    for col in viz.numeric_columns:
+        fig = ctx.get_figure(f'univariate.{col}.hist')
+        assert fig is not None
+        assert len(fig.data) > 1


### PR DESCRIPTION
## Summary
- add optional KDE overlay to histogram helper
- compute skewness and kurtosis for numeric columns
- persist KDE histograms for each numeric column in `UnivariateStage`
- extend tests for new behaviour and add dependency for styling tables
- fix newline in requirements

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68796280bac08321ab4024653d97a168