### PR TITLE
Add feature advice module

### DIFF
--- a/feature_advice.py
+++ b/feature_advice.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+import pandas as pd
+from stages.base import BaseStage
+from analysis_context import AnalysisContext
+from bigquery_visualizer import BigQueryVisualizer
+
+
+class FeatureAdviceStage(BaseStage):
+    """Suggest encoding, scaling and imputation strategies."""
+
+    id = "feature_advice"
+
+    def run(self, viz: BigQueryVisualizer, ctx: AnalysisContext):
+        missing = ctx.get_table("quality.missing_pct")
+        cat_quality = ctx.get_table("quality.categorical_quality")
+        num_stats = ctx.get_table("univariate.numeric_stats")
+        corr = ctx.get_table("bivariate.pearson_corr")
+
+        enc_rows, imp_rows, scale_rows, inter_rows = [], [], [], []
+
+        def missing_pct(col: str) -> float:
+            if missing is None or missing.empty:
+                return 0.0
+            row = missing[missing["column"] == col]
+            return float(row["missing_pct"].iloc[0]) if not row.empty else 0.0
+
+        def skew(col: str) -> float:
+            if num_stats is None or num_stats.empty:
+                return 0.0
+            row = num_stats[num_stats["Column"] == col]
+            if row.empty:
+                row = num_stats[num_stats["column"] == col]
+            return float(row["Skewness"].iloc[0]) if not row.empty else 0.0
+
+        def n_categories(col: str) -> int:
+            if cat_quality is None or cat_quality.empty:
+                return 0
+            row = cat_quality[cat_quality["column"] == col]
+            return int(row["categories"].iloc[0]) if not row.empty else 0
+
+        # --- encoding + imputation + scaling suggestions ---
+        for col in viz.numeric_columns:
+            mp = missing_pct(col)
+            sk = skew(col)
+            enc_rows.append({"column": col, "encoding": "numeric"})
+            if mp > 0:
+                imp_rows.append({"column": col, "strategy": "median" if abs(sk) > 1 else "mean"})
+            else:
+                imp_rows.append({"column": col, "strategy": "none"})
+            scale_rows.append({"column": col, "scaling": "log" if abs(sk) > 1 else "standard"})
+
+        for col in viz.categorical_columns:
+            cats = n_categories(col)
+            mp = missing_pct(col)
+            encoding = "one-hot" if cats and cats <= 20 else "target"
+            enc_rows.append({"column": col, "encoding": encoding})
+            strategy = "mode" if mp < 30 else "constant('missing')"
+            imp_rows.append({"column": col, "strategy": strategy})
+
+        for col in viz.datetime_columns:
+            enc_rows.append({"column": col, "encoding": "datetime"})
+            mp = missing_pct(col)
+            imp_rows.append({"column": col, "strategy": "drop" if mp > 50 else "none"})
+            inter_rows.append({"feature_1": col, "feature_2": "", "suggestion": "lag_features"})
+
+        # --- interaction ideas based on correlation ---
+        if corr is not None and not corr.empty:
+            for i, col1 in enumerate(viz.numeric_columns):
+                for col2 in viz.numeric_columns[i+1:]:
+                    if col1 in corr.index and col2 in corr.columns:
+                        val = corr.loc[col1, col2]
+                    elif col2 in corr.index and col1 in corr.columns:
+                        val = corr.loc[col2, col1]
+                    else:
+                        continue
+                    if pd.notna(val) and abs(val) > 0.7:
+                        inter_rows.append({"feature_1": col1, "feature_2": col2, "suggestion": "polynomial"})
+
+        ctx.add_table(self.key("encoding_plan"), pd.DataFrame(enc_rows))
+        ctx.add_table(self.key("imputation_plan"), pd.DataFrame(imp_rows))
+        ctx.add_table(self.key("scaling_plan"), pd.DataFrame(scale_rows))
+        ctx.add_table(self.key("interaction_plan"), pd.DataFrame(inter_rows))

--- a/pipeline.py
+++ b/pipeline.py
@@ -13,6 +13,7 @@ from stages.core_stages import (
     MultivariateStage,
     TargetStage,
 )
+from feature_advice import FeatureAdviceStage
 
 # default chain (order matters)
 DEFAULT_STAGE_CHAIN: Sequence = [
@@ -22,6 +23,7 @@ DEFAULT_STAGE_CHAIN: Sequence = [
     BivariateStage(),
     MultivariateStage(),
     TargetStage(),
+    FeatureAdviceStage(),
 ]
 
 

--- a/readme.md
+++ b/readme.md
@@ -19,6 +19,7 @@
 | `analysis_context.py` | In-memory store for result tables & figures—later export to HTML / Markdown. |
 | cost guard | Dry-run every query; abort if bytes scanned > configurable limit (default 1 GB). |
 | cache | In-memory DataFrame cache per notebook session—re-plots are instant, no extra BigQuery cost. |
+| `feature_advice.py` | Auto-suggest encoding, scaling and interaction plans based on profiling results. |
 
 ---
 
@@ -67,4 +68,11 @@ ctx = Pipeline().run(viz)
 ctx.get_table("quality.unique_ratio")          # unique-value ratios
 ctx.get_table("quality.categorical_quality")   # categorical singleton stats
 ctx.get_table("target.class_balance")          # distribution of target classes
+ctx.get_table("feature_advice.encoding_plan")  # suggested encodings
+ctx.get_table("feature_advice.imputation_plan")  # how to fill missing values
 ```
+
+The `FeatureAdviceStage` consumes earlier statistics to auto‑generate
+encoding, imputation and scaling suggestions, plus a list of possible
+interaction terms. These tables can guide feature engineering for a
+machine learning model.

--- a/tests/test_feature_advice.py
+++ b/tests/test_feature_advice.py
@@ -1,0 +1,53 @@
+import os, sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import pandas as pd
+from analysis_context import AnalysisContext
+from feature_advice import FeatureAdviceStage
+
+class DummyViz:
+    def __init__(self):
+        self.full_table_path = 'x'
+        self.numeric_columns = ['num1', 'num2']
+        self.categorical_columns = ['cat']
+        self.datetime_columns = ['date']
+        self.columns = self.numeric_columns + self.categorical_columns + self.datetime_columns
+
+
+def _ctx_with_metrics():
+    ctx = AnalysisContext()
+    ctx.add_table(
+        'quality.missing_pct',
+        pd.DataFrame({'column':['num1','num2','cat','date'], 'missing_pct':[10,0,5,60]})
+    )
+    ctx.add_table(
+        'quality.categorical_quality',
+        pd.DataFrame({'column':['cat'], 'categories':[3]})
+    )
+    ctx.add_table(
+        'univariate.numeric_stats',
+        pd.DataFrame({'Column':['num1','num2'], 'Skewness':[2.0,0.1]})
+    )
+    corr = pd.DataFrame(
+        [[1.0,0.8],[0.8,1.0]],
+        index=['num1','num2'],
+        columns=['num1','num2']
+    )
+    ctx.add_table('bivariate.pearson_corr', corr)
+    return ctx
+
+
+def test_feature_advice_outputs():
+    ctx = _ctx_with_metrics()
+    viz = DummyViz()
+    FeatureAdviceStage().run(viz, ctx)
+
+    enc = ctx.get_table('feature_advice.encoding_plan')
+    imp = ctx.get_table('feature_advice.imputation_plan')
+    scale = ctx.get_table('feature_advice.scaling_plan')
+    inter = ctx.get_table('feature_advice.interaction_plan')
+
+    assert {'num1','num2','cat','date'} <= set(enc['column'])
+    assert imp.loc[imp['column']=='num1','strategy'].iloc[0] == 'median'
+    assert scale.loc[scale['column']=='num2','scaling'].iloc[0] == 'standard'
+    assert not inter.empty


### PR DESCRIPTION
## Summary
- create `FeatureAdviceStage` to propose encoding, scaling, imputation and interaction plans
- include stage at the end of the default pipeline
- document feature advice tables in README
- test advice generation logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879c4284e6c83219379ce7bbce3001f