### PR TITLE
Add query result-size guard and cache threshold

### DIFF
--- a/bigquery_visualizer.py
+++ b/bigquery_visualizer.py
@@ -19,7 +19,15 @@ class BigQueryVisualizer:
     An enhanced class to connect to a BigQuery table and generate visualizations
     and descriptive analyses directly in a Python notebook.
     """
-    def __init__(self, project_id: str, table_id: str, credentials_path: str = None, max_bytes_scanned: int = 10_000_000_000):
+    def __init__(
+        self,
+        project_id: str,
+        table_id: str,
+        credentials_path: str = None,
+        max_bytes_scanned: int = 10_000_000_000,
+        max_result_bytes: int = 2_000_000_000,
+        cache_threshold_bytes: int = 100_000_000,
+    ):
         """
         Initializes the visualizer with BigQuery credentials and table info.
 
@@ -28,12 +36,17 @@ class BigQueryVisualizer:
             table_id (str): The full ID of the BigQuery table (e.g., 'your_dataset.your_table_name').
             credentials_path (str, optional): Path to your GCP service account JSON file.
                                               If None, relies on default authentication.
+            max_bytes_scanned (int): Abort if a dry run estimates scanning more than this many bytes.
+            max_result_bytes (int): Abort if ``EXPLAIN`` estimates results larger than this many bytes.
+            cache_threshold_bytes (int): Only cache DataFrames smaller than this size.
         """
         self.project_id = project_id
         self.table_id = table_id
         self.full_table_path = f"`{self.project_id}.{self.table_id}`"
         self._query_cache: dict[str, pd.DataFrame] = {}
         self.max_bytes_scanned = max_bytes_scanned
+        self.max_result_bytes = max_result_bytes
+        self.cache_threshold_bytes = cache_threshold_bytes
         
         if credentials_path:
             self.credentials = service_account.Credentials.from_service_account_file(credentials_path)
@@ -101,13 +114,32 @@ class BigQueryVisualizer:
                 f"Query would process {dry_job.total_bytes_processed/1e9:.2f} GB "
                 f"(limit {self.max_bytes_scanned/1e9:.2f} GB). Aborting."
             )
-        
+
+        # Estimate result size before executing
+        est_bytes = 0
+        try:
+            plan_job = self.client.query(f"EXPLAIN {query}")
+            plan_job.result()
+            if plan_job.query_plan:
+                final = plan_job.query_plan[-1]
+                est_bytes = int(
+                    final._properties.get("statistics", {}).get("estimatedBytes", 0)
+                )
+        except Exception:
+            est_bytes = 0
+
+        if est_bytes and est_bytes > self.max_result_bytes:
+            raise RuntimeError(
+                f"Query would return {est_bytes/1e9:.2f} GB "
+                f"(limit {self.max_result_bytes/1e9:.2f} GB). Aborting."
+            )
+
         print(f"ℹ️ Query will process {dry_job.total_bytes_processed/1e9:.2f} GB")
-    
+
         try:
             query_job = self.client.query(query)
             df = query_job.to_dataframe()
-            if use_cache:
+            if use_cache and df.memory_usage(deep=True).sum() < self.cache_threshold_bytes:
                 self._query_cache[query] = df.copy()
             return df
         except Exception as e:

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@
 * Plotly-powered charts  
 * SQL-first, Python-light: heavy lifting stays in BigQuery  
 * Modular pipeline (run everything) **and** standalone helpers  
-* Built-in query cache + cost guard (no surprise bills)
+* Built-in query cache + cost guard (dry-run + result-size check)
 
 ---
 
@@ -17,8 +17,8 @@
 | `stages/` | Each `Stage` runs one slice of EDA (profiling, quality, univariate, …) and writes artefacts into a shared `AnalysisContext`. |
 | `pipeline.py` | Orchestrator that executes any list of stages: `Pipeline().run(viz)`. |
 | `analysis_context.py` | In-memory store for result tables & figures—later export to HTML / Markdown. |
-| cost guard | Dry-run every query; abort if bytes scanned > configurable limit (default 1 GB). |
-| cache | In-memory DataFrame cache per notebook session—re-plots are instant, no extra BigQuery cost. |
+| cost guard | Dry-run every query; abort if bytes scanned > configurable limit (default 1 GB) and if `EXPLAIN` estimates the result exceeds `max_result_bytes` (default 2 GB). |
+| cache | DataFrames are cached per session only when their memory usage is below `cache_threshold_bytes` (default 100 MB). |
 | `feature_advice.py` | Auto-suggest encoding, scaling and interaction plans based on profiling results. |
 
 ---
@@ -41,6 +41,9 @@ viz = BigQueryVisualizer(
     project_id="my-project",
     table_id="dataset.table",
     credentials_path="path/to/key.json",
+    # optional guards:
+    # max_result_bytes=2_000_000_000,
+    # cache_threshold_bytes=100_000_000,
 )
 
 # run the default EDA pipeline

--- a/tests/test_execute_query_guard.py
+++ b/tests/test_execute_query_guard.py
@@ -1,0 +1,65 @@
+import os, sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import pandas as pd
+import pytest
+
+from bigquery_visualizer import BigQueryVisualizer
+
+class FakePlanEntry:
+    def __init__(self, est):
+        self._properties = {"statistics": {"estimatedBytes": est}}
+
+class FakeDryJob:
+    def __init__(self, scanned=0):
+        self.total_bytes_processed = scanned
+    def result(self):
+        pass
+
+class FakePlanJob:
+    def __init__(self, est):
+        self.query_plan = [FakePlanEntry(est)]
+    def result(self):
+        pass
+
+class FakeResultJob:
+    def __init__(self, df):
+        self._df = df
+    def to_dataframe(self):
+        return self._df
+
+class DummyClient:
+    def __init__(self, est_bytes, df):
+        self.est_bytes = est_bytes
+        self.df = df
+    def query(self, q, job_config=None):
+        if job_config is not None:
+            return FakeDryJob()
+        if q.startswith("EXPLAIN"):
+            return FakePlanJob(self.est_bytes)
+        return FakeResultJob(self.df)
+
+class DummyViz(BigQueryVisualizer):
+    def __init__(self, est_bytes=0, df=None, cache_threshold=100):
+        self.project_id = 'p'
+        self.table_id = 'd.t'
+        self.full_table_path = 'x'
+        self._query_cache = {}
+        self.max_bytes_scanned = 10_000
+        self.max_result_bytes = 2_000_000_000
+        self.cache_threshold_bytes = cache_threshold
+        self.client = DummyClient(est_bytes, df if df is not None else pd.DataFrame())
+
+
+def test_result_size_guard_raises():
+    viz = DummyViz(est_bytes=3_000_000_000, df=pd.DataFrame())
+    with pytest.raises(RuntimeError):
+        viz._execute_query("SELECT 1")
+
+
+def test_big_df_not_cached():
+    df = pd.DataFrame({'a': range(1000)})
+    viz = DummyViz(est_bytes=0, df=df, cache_threshold=1)
+    out = viz._execute_query("SELECT 1")
+    assert out.equals(df)
+    assert "SELECT 1" not in viz._query_cache


### PR DESCRIPTION
## Summary
- estimate result size before executing queries
- cache DataFrames only when under a configurable threshold
- document `max_result_bytes` and `cache_threshold_bytes`
- test result-size guard and caching behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879ede502ac8321bfdd2a7282c9fe51