### PR TITLE
Add representative sampling cache

### DIFF
--- a/tests/test_bivariate_stage.py
+++ b/tests/test_bivariate_stage.py
@@ -11,6 +11,7 @@ class DummyViz:
         self.numeric_columns = ['n1', 'n2']
         self.categorical_columns = ['cat1', 'cat2']
         self.columns = self.numeric_columns + self.categorical_columns
+        self.rep_sample_df = None
     def _execute_query(self, q, use_cache=True):
         if 'GROUP BY cat1, cat2' in q:
             return pd.DataFrame({'cat1':['A','A','B','B'], 'cat2':['X','Y','X','Y'], 'n':[50,5,5,50]})
@@ -27,6 +28,19 @@ class DummyViz:
             if 'n2' in q:
                 return pd.DataFrame({'cat2':['X','Y','X','Y'], 'n2':[10,20,30,40]})
         return pd.DataFrame()
+
+    def get_representative_sample(self, columns=None, max_bytes=None, refresh=False):
+        if self.rep_sample_df is None or refresh:
+            self.rep_sample_df = pd.DataFrame({
+                'n1':[1,2,3,4],
+                'n2':[10,20,30,40],
+                'cat1':['A','B','A','B'],
+                'cat2':['X','Y','X','Y']
+            })
+        df = self.rep_sample_df.copy()
+        if columns:
+            df = df[columns]
+        return df
 
 def test_bivariate_stage_basic():
     ctx = AnalysisContext(params={'lowess_plots': True})

--- a/tests/test_missingness.py
+++ b/tests/test_missingness.py
@@ -10,8 +10,15 @@ class DummyViz(BigQueryVisualizer):
         self.columns = list(df.columns)
         self.numeric_columns = []
         self._df = df
+        self.rep_sample_df = df.copy()
     def _execute_query(self, q, use_cache=True):
         return self._df.copy()
+
+    def get_representative_sample(self, columns=None, max_bytes=None, refresh=False):
+        df = self.rep_sample_df.copy()
+        if columns:
+            df = df[columns]
+        return df
 
 
 def test_missingness_functions():

--- a/tests/test_multivariate_stage.py
+++ b/tests/test_multivariate_stage.py
@@ -12,12 +12,23 @@ class DummyViz(BigQueryVisualizer):
         self.numeric_columns = ['n1', 'n2', 'n3']
         self.categorical_columns = []
         self.columns = self.numeric_columns
+        self.rep_sample_df = pd.DataFrame({
+            'n1':[1,2,3,4,5],
+            'n2':[2,4,6,8,10],
+            'n3':[5,3,6,2,1]
+        })
     def _execute_query(self, q, use_cache=True):
         return pd.DataFrame({
             'n1':[1,2,3,4,5],
             'n2':[2,4,6,8,10],
             'n3':[5,3,6,2,1]
         })
+
+    def get_representative_sample(self, columns=None, max_bytes=None, refresh=False):
+        df = self.rep_sample_df.copy()
+        if columns:
+            df = df[columns]
+        return df
 
 
 def test_multivariate_stage_projections():

--- a/tests/test_quality_stage.py
+++ b/tests/test_quality_stage.py
@@ -13,6 +13,11 @@ class DummyViz:
         self.columns = ['a', 'num1', 'cat1']
         self.numeric_columns = ['num1']
         self.categorical_columns = ['cat1']
+        self.rep_sample_df = pd.DataFrame({
+            'a':[1,2,3,4],
+            'num1':[1,2,3,100],
+            'cat1':['x','y','x','z']
+        })
     def _execute_query(self, q, use_cache=True):
         if 'TO_JSON_STRING' in q:
             return pd.DataFrame({'total':[100], 'distinct_rows':[95]})
@@ -27,6 +32,12 @@ class DummyViz:
         if 'TABLESAMPLE' in q:
             return pd.DataFrame({'num1':[1,2,3,100]})
         return pd.DataFrame()
+
+    def get_representative_sample(self, columns=None, max_bytes=None, refresh=False):
+        df = self.rep_sample_df.copy()
+        if columns:
+            df = df[columns]
+        return df
 
     def missingness_map(self, columns=None, sample_rows=100000):
         df = pd.DataFrame({'a':[1,2], 'num1':[1,2], 'cat1':['x','y']})

--- a/tests/test_rep_sample.py
+++ b/tests/test_rep_sample.py
@@ -1,0 +1,58 @@
+import os, sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import pandas as pd
+from pathlib import Path
+from bigquery_visualizer import BigQueryVisualizer
+
+class DummyViz(BigQueryVisualizer):
+    def __init__(self):
+        self.full_table_path = 'x'
+        self._query_cache = {}
+        self.max_result_bytes = 100
+        self.schema_df = pd.DataFrame({
+            'column_name': ['a', 'b'],
+            'data_type': ['INT64', 'STRING'],
+            'category': ['numeric', 'string'],
+        })
+        self.columns = ['a', 'b']
+        self.numeric_columns = ['a']
+        self.categorical_columns = ['b']
+        self.string_columns = ['b']
+        self.boolean_columns = []
+        self.datetime_columns = []
+        self.complex_columns = []
+        self.geographic_columns = []
+        self.client = None
+        self.sample_cache_dir = Path("/tmp/test_cache")
+        self.sample_cache_dir.mkdir(exist_ok=True)
+        self.rep_sample_columns_key = None
+        self.rep_sample_df = None
+        self._calls = 0
+    def _execute_query(self, q, use_cache=True):
+        self.last_query = q
+        self._calls += 1
+        return pd.DataFrame({'a':[1], 'b':['x']})
+    def evaluate_sample_bias(self, sample_rows=1000, alpha=0.05):
+        self.bias_called = True
+        return pd.DataFrame()
+
+    def get_representative_sample(self, columns=None, max_bytes=None, refresh=False):
+        return super().get_representative_sample(columns=columns, max_bytes=max_bytes, refresh=refresh)
+
+def test_representative_sample_cached():
+    viz = DummyViz()
+    df1 = viz.get_representative_sample()
+    assert 'LIMIT 3' in viz.last_query
+    assert viz.bias_called
+    calls = viz._calls
+    df2 = viz.get_representative_sample()
+    assert viz._calls == calls
+    assert df1.equals(df2)
+
+def test_representative_sample_refresh():
+    viz = DummyViz()
+    viz.get_representative_sample()
+    calls = viz._calls
+    viz.get_representative_sample(refresh=True)
+    assert viz._calls == calls + 1


### PR DESCRIPTION
## Summary
- add disk-based representative sample caching with column selection
- update stages and utilities to request only needed columns
- adjust tests for new sample caching behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879f03888608321991de84fdd556864