### PR TITLE
Use SQL primitives for histogram and correlations

### DIFF
--- a/stages/core_stages.py
+++ b/stages/core_stages.py
@@ -232,25 +232,25 @@ class BivariateStage(BaseStage):
 
         # ─── Numeric correlations ──────────────────────────────────────
         if num_cols:
-            df = viz.get_representative_sample(columns=num_cols)
-            if len(df) > sample_n:
-                df = df.sample(sample_n, random_state=42)
-            if not df.empty:
-                pear = df.corr(method="pearson")
+            pear = viz.numeric_correlations(num_cols, method="pearson")
+            if not pear.empty:
                 ctx.add_table(self.key("pearson_corr"), pear)
                 fig = px.imshow(pear, title="Numeric Correlation Matrix", color_continuous_scale="RdBu_r")
                 ctx.add_figure(self.key("corr_heatmap"), fig)
 
-                spear = df.corr(method="spearman")
+            spear = viz.numeric_correlations(num_cols, method="spearman")
+            if not spear.empty:
                 ctx.add_table(self.key("spearman_corr"), spear)
 
-                if ctx.params.get("lowess_plots"):
-                    from itertools import combinations
-
-                    for x, y in combinations(num_cols[:5], 2):
-                        fig = px.scatter(df, x=x, y=y, trendline="lowess",
-                                         title=f"{y} vs {x} (LOWESS)")
-                        ctx.add_figure(self.key(f"{y}_vs_{x}.lowess"), fig)
+            if ctx.params.get("lowess_plots"):
+                from itertools import combinations
+                df = viz.get_representative_sample(columns=num_cols[:5])
+                for x, y in combinations(num_cols[:5], 2):
+                    if df.empty:
+                        break
+                    fig = px.scatter(df, x=x, y=y, trendline="lowess",
+                                     title=f"{y} vs {x} (LOWESS)")
+                    ctx.add_figure(self.key(f"{y}_vs_{x}.lowess"), fig)
 
         # ─── Numeric ~ Categorical tests ───────────────────────────────
         numcat_results = []

--- a/tests/test_bivariate_stage.py
+++ b/tests/test_bivariate_stage.py
@@ -13,21 +13,14 @@ class DummyViz:
         self.columns = self.numeric_columns + self.categorical_columns
         self.rep_sample_df = None
     def _execute_query(self, q, use_cache=True):
+        if 'CORR(' in q:
+            return pd.DataFrame({'c1':['n1'], 'c2':['n2'], 'corr':[0.5]})
         if 'GROUP BY cat1, cat2' in q:
             return pd.DataFrame({'cat1':['A','A','B','B'], 'cat2':['X','Y','X','Y'], 'n':[50,5,5,50]})
-        if 'TABLESAMPLE SYSTEM' in q and 'n1' in q and 'n2' in q and 'WHERE' not in q:
-            return pd.DataFrame({'n1':[1,2,3,4], 'n2':[10,20,30,40]})
-        if 'TABLESAMPLE SYSTEM' in q and 'WHERE cat1 IS NOT NULL' in q:
-            if 'n1' in q:
-                return pd.DataFrame({'cat1':['A','B','A','B'], 'n1':[1,2,3,4]})
-            if 'n2' in q:
-                return pd.DataFrame({'cat1':['A','B','A','B'], 'n2':[10,20,30,40]})
-        if 'TABLESAMPLE SYSTEM' in q and 'WHERE cat2 IS NOT NULL' in q:
-            if 'n1' in q:
-                return pd.DataFrame({'cat2':['X','Y','X','Y'], 'n1':[1,2,3,4]})
-            if 'n2' in q:
-                return pd.DataFrame({'cat2':['X','Y','X','Y'], 'n2':[10,20,30,40]})
         return pd.DataFrame()
+
+    def numeric_correlations(self, columns, method='pearson'):
+        return pd.DataFrame([[1.0, 0.5],[0.5,1.0]], index=columns, columns=columns)
 
     def get_representative_sample(self, columns=None, max_bytes=None, refresh=False):
         if self.rep_sample_df is None or refresh:

--- a/tests/test_histogram_kde.py
+++ b/tests/test_histogram_kde.py
@@ -5,18 +5,27 @@ import pandas as pd
 from bigquery_visualizer import BigQueryVisualizer
 
 class DummyViz(BigQueryVisualizer):
-    def __init__(self, df):
+    def __init__(self):
         self.full_table_path = 'x'
-        self.columns = list(df.columns)
+        self.columns = ['num']
         self.numeric_columns = ['num']
         self.categorical_columns = []
-        self._df = df
+
     def _execute_query(self, q, use_cache=True):
-        return self._df.copy()
+        if 'APPROX_QUANTILES' in q:
+            return pd.DataFrame({
+                'bucket':[1,2],
+                'bin_start':[0,5],
+                'bin_end':[5,10],
+                'n':[2,4]
+            })
+        return pd.DataFrame()
+
+    def get_representative_sample(self, columns=None, max_bytes=None, refresh=False):
+        return pd.DataFrame({'num':[1,2,2,3,4,5]})
 
 def test_histogram_with_kde():
-    df = pd.DataFrame({'num':[1,2,2,3,4,5]})
-    viz = DummyViz(df)
+    viz = DummyViz()
     _, fig = viz.plot_histogram(numeric_column='num', kde=True, bins=5)
     assert fig is not None
     assert len(fig.data) > 1

--- a/tests/test_multivariate_stage.py
+++ b/tests/test_multivariate_stage.py
@@ -18,6 +18,8 @@ class DummyViz(BigQueryVisualizer):
             'n3':[5,3,6,2,1]
         })
     def _execute_query(self, q, use_cache=True):
+        if 'ML.PCA' in q or 'ML.TSNE' in q or 'ML.UMAP' in q:
+            return pd.DataFrame({'dim1':[0.1,0.2], 'dim2':[0.2,0.4]})
         return pd.DataFrame({
             'n1':[1,2,3,4,5],
             'n2':[2,4,6,8,10],

--- a/tests/test_sql_helpers.py
+++ b/tests/test_sql_helpers.py
@@ -1,0 +1,36 @@
+import os, sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import pandas as pd
+from bigquery_visualizer import BigQueryVisualizer
+
+class DummyViz(BigQueryVisualizer):
+    def __init__(self):
+        self.full_table_path = 'x'
+        self.columns = ['a', 'b']
+        self.numeric_columns = ['a', 'b']
+        self.categorical_columns = []
+
+    def _execute_query(self, q, use_cache=True):
+        if 'CORR(' in q:
+            return pd.DataFrame({'c1':['a'], 'c2':['b'], 'corr':[0.7]})
+        if 'ML.PCA' in q:
+            return pd.DataFrame({'dim1':[0.1], 'dim2':[0.2]})
+        if 'APPROX_QUANTILES' in q:
+            return pd.DataFrame({'bucket':[1], 'bin_start':[0], 'bin_end':[5], 'n':[10]})
+        return pd.DataFrame()
+
+    def get_representative_sample(self, columns=None, max_bytes=None, refresh=False):
+        return pd.DataFrame({'a':[1,2], 'b':[3,4]})
+
+def test_numeric_correlations():
+    viz = DummyViz()
+    mat = viz.numeric_correlations(['a','b'])
+    assert mat.loc['a','b'] == 0.7
+    assert mat.loc['b','a'] == 0.7
+
+def test_project_2d_sql():
+    viz = DummyViz()
+    df, fig = viz.project_2d(method='pca', columns=['a','b'])
+    assert not df.empty
+    assert 'dim1' in df.columns and 'dim2' in df.columns

--- a/tests/test_univariate_stage.py
+++ b/tests/test_univariate_stage.py
@@ -23,11 +23,20 @@ class DummyViz(BigQueryVisualizer):
                 'total_rows':[4],'null_count':[0],'non_null_count':[4],
                 'mean':[25],'std_dev':[11.2],'variance':[125.0],'min':[10],'max':[40],
                 'skewness':[0.0],'kurtosis':[1.5],'quartiles':[[10,17.5,25,32.5,40]]})
-        if 'SELECT num1' in q:
-            return pd.DataFrame({'num1':[1,2,3,4]})
-        if 'SELECT num2' in q:
-            return pd.DataFrame({'num2':[10,20,30,40]})
+        if 'APPROX_QUANTILES' in q:
+            return pd.DataFrame({
+                'bucket':[1,2],
+                'bin_start':[0,5],
+                'bin_end':[5,10],
+                'n':[2,2]
+            })
         return pd.DataFrame()
+
+    def get_representative_sample(self, columns=None, max_bytes=None, refresh=False):
+        df = pd.DataFrame({'num1':[1,2,3,4], 'num2':[10,20,30,40]})
+        if columns:
+            df = df[columns]
+        return df
 
 
 def test_univariate_stage_kde_histograms():


### PR DESCRIPTION
## Summary
- compute histograms with BigQuery `APPROX_QUANTILES`
- derive correlations using `CORR` and SQL ranks
- project numeric data using BigQuery ML
- update bivariate and multivariate stages
- adjust unit tests and add new SQL helper tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879f56498fc8321aa112922f066541e