### PR TITLE
Add guarded BigQuery executor

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -65,6 +65,13 @@ splits, balance = viz.generate_splits(
     method="stratified",
 )
 print(balance)
+
+# run a custom query with guard logic only
+from bq_eda_toolkit.utils.bq_executor import execute_query_with_guard
+row_count_df = execute_query_with_guard(
+    viz.client,
+    "SELECT COUNT(*) AS n FROM dataset.table",
+)
 ```
 
 Visualisation functions return Plotly or Matplotlib objects. They do not call

--- a/tests/test_execute_query_guard.py
+++ b/tests/test_execute_query_guard.py
@@ -6,6 +6,7 @@ import pandas as pd
 import pytest
 
 from bq_eda_toolkit.bigquery_visualizer import BigQueryVisualizer, QueryExecutionError
+from bq_eda_toolkit.utils.bq_executor import execute_query_with_guard
 
 class FakePlanEntry:
     def __init__(self, est):

--- a/utils/bq_executor.py
+++ b/utils/bq_executor.py
@@ -1,0 +1,37 @@
+import logging
+from google.cloud import bigquery
+
+logger = logging.getLogger(__name__)
+
+def execute_query_with_guard(client, sql, job_config=None, max_gb_processed=1.0, max_result_bytes=2_000_000_000):
+    """Execute a BigQuery SQL query with a dry-run and result-size guard."""
+    cfg = bigquery.QueryJobConfig(dry_run=True, use_query_cache=True)
+    dry_job = client.query(sql, job_config=cfg)
+    if dry_job.total_bytes_processed > max_gb_processed * 1e9:
+        raise RuntimeError(
+            f"Query would process {dry_job.total_bytes_processed/1e9:.2f} GB "
+            f"(limit {max_gb_processed:.2f} GB). Aborting."
+        )
+
+    est_bytes = 0
+    try:
+        plan_job = client.query(f"EXPLAIN {sql}")
+        plan_job.result()
+        if plan_job.query_plan:
+            final = plan_job.query_plan[-1]
+            est_bytes = int(
+                final._properties.get("statistics", {}).get("estimatedBytes", 0)
+            )
+    except Exception:
+        est_bytes = 0
+
+    if est_bytes and est_bytes > max_result_bytes:
+        raise RuntimeError(
+            f"Query would return {est_bytes/1e9:.2f} GB "
+            f"(limit {max_result_bytes/1e9:.2f} GB). Aborting."
+        )
+
+    logger.info("ℹ️ Query will process %0.2f GB", dry_job.total_bytes_processed / 1e9)
+
+    job = client.query(sql, job_config=job_config)
+    return job.to_dataframe()


### PR DESCRIPTION
## Summary
- add `utils.bq_executor.execute_query_with_guard`
- use new util in `BigQueryVisualizer._execute_query`
- reference the util in README usage docs
- update tests to import the util

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b1a3f125083218ff76e29660e672c