### PR TITLE
Add RepSampleStage with stratified sampling

### DIFF
--- a/bigquery_visualizer.py
+++ b/bigquery_visualizer.py
@@ -13,6 +13,7 @@ from sklearn.cluster import KMeans
 from sklearn.metrics import silhouette_score
 from sklearn.neighbors import NearestNeighbors
 import logging
+from .stages.core_stages import RepSampleStage
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -1529,25 +1530,24 @@ class BigQueryVisualizer:
         ):
             return self.rep_sample_df.copy()
 
-        limit_bytes = max_bytes or self.max_result_bytes
-        size_map = {
-            "numeric": 8,
-            "string": 20,
-            "boolean": 1,
-            "datetime": 8,
-            "complex": 50,
-            "geographic": 16,
-            "other": 8,
-        }
-        cat_lookup = dict(zip(self.schema_df["column_name"], self.schema_df["category"]))
-        row_bytes = sum(size_map.get(cat_lookup.get(c, "other"), 8) for c in cols)
-        row_bytes = max(1, row_bytes)
-        max_rows = max(1, limit_bytes // row_bytes)
+        n_override = None
+        if max_bytes is not None:
+            size_map = {
+                "numeric": 8,
+                "string": 20,
+                "boolean": 1,
+                "datetime": 8,
+                "complex": 50,
+                "geographic": 16,
+                "other": 8,
+            }
+            cat_lookup = dict(zip(self.schema_df["column_name"], self.schema_df["category"]))
+            row_bytes = sum(size_map.get(cat_lookup.get(c, "other"), 8) for c in cols)
+            row_bytes = max(1, row_bytes)
+            n_override = max(1, max_bytes // row_bytes)
 
-        query = (
-            f"SELECT {', '.join(cols)} FROM {self.full_table_path} TABLESAMPLE SYSTEM (1 PERCENT) "
-            f"LIMIT {max_rows}"
-        )
+        stage = RepSampleStage(n=n_override, columns=cols)
+        query = stage.build_query(self)
         df = self._execute_query(query)
         if not df.empty:
             self.evaluate_sample_bias(sample_rows=min(1000, len(df)))

--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,7 @@
 | cost guard | Dry-run every query; abort if bytes scanned > configurable limit (default 1 GB) and if `EXPLAIN` estimates the result exceeds `max_result_bytes` (default 2 GB). |
 | cache | DataFrames are cached per session only when their memory usage is below `cache_threshold_bytes` (default 100 MB). |
 | `feature_advice.py` | Auto-suggest encoding, scaling and interaction plans based on profiling results. |
+| `RepSampleStage` | Build representative samples via `TABLESAMPLE` or stratified sampling. |
 
 ---
 

--- a/stages/__init__.py
+++ b/stages/__init__.py
@@ -1,0 +1,22 @@
+"""Expose commonly used Stage classes."""
+
+from .core_stages import (
+    ProfilingStage,
+    QualityStage,
+    UnivariateStage,
+    BivariateStage,
+    MultivariateStage,
+    TargetStage,
+    RepSampleStage,
+)
+
+__all__ = [
+    "ProfilingStage",
+    "QualityStage",
+    "UnivariateStage",
+    "BivariateStage",
+    "MultivariateStage",
+    "TargetStage",
+    "RepSampleStage",
+]
+

--- a/stages/base.py
+++ b/stages/base.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 from abc import ABC, abstractmethod
-from typing import Any
+from typing import Any, TYPE_CHECKING
 from ..analysis_context import AnalysisContext
-from ..bigquery_visualizer import BigQueryVisualizer   # adjust import path if needed
+if TYPE_CHECKING:  # avoid circular import at runtime
+    from ..bigquery_visualizer import BigQueryVisualizer
 
 
 class BaseStage(ABC):

--- a/tests/test_rep_sample_stage.py
+++ b/tests/test_rep_sample_stage.py
@@ -1,0 +1,60 @@
+import os, sys
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+
+import pandas as pd
+from bq_eda_toolkit.stages.core_stages import RepSampleStage
+from bq_eda_toolkit.bigquery_visualizer import BigQueryVisualizer
+
+class DummyViz(BigQueryVisualizer):
+    def __init__(self):
+        self.full_table_path = 'ds.tbl'
+        self.table_rows = 1000
+        self.max_result_bytes = 100
+        self.schema_df = pd.DataFrame({
+            'column_name': ['a', 'b'],
+            'data_type': ['INT64', 'STRING'],
+            'category': ['numeric', 'string'],
+        })
+        self.columns = ['a', 'b']
+        self.numeric_columns = ['a']
+        self.categorical_columns = ['b']
+        self.string_columns = ['b']
+        self.boolean_columns = []
+        self.datetime_columns = []
+        self.complex_columns = []
+        self.geographic_columns = []
+        self.auto_show = False
+
+    def _execute_query(self, q, use_cache=True):
+        self.last_query = q
+        return pd.DataFrame({'a':[1],'b':['x']})
+
+
+def test_tablesample_query_generation():
+    viz = DummyViz()
+    stage = RepSampleStage(n=100, columns=['a','b'])
+    q = stage.build_query(viz)
+    assert 'TABLESAMPLE SYSTEM (10 PERCENT)' in q
+    assert 'LIMIT 100' in q
+
+
+def test_stratified_query_generation():
+    viz = DummyViz()
+    stage = RepSampleStage(n=100, method='STRATIFIED', stratify_by='b', columns=['a','b'])
+    q = stage.build_query(viz)
+    assert 'ROW_NUMBER() OVER(PARTITION BY b' in q
+    assert 'CEIL(cnt * 10 / 100)' in q
+
+
+def test_auto_limit_from_max_bytes():
+    viz = DummyViz()
+    stage = RepSampleStage(columns=['a','b'])
+    q = stage.build_query(viz)
+    assert 'LIMIT 3' in q
+
+
+def test_explicit_sample_percent():
+    viz = DummyViz()
+    stage = RepSampleStage(sample_percent=5, columns=['a','b'])
+    q = stage.build_query(viz)
+    assert 'TABLESAMPLE SYSTEM (5 PERCENT)' in q


### PR DESCRIPTION
## Summary
- implement `RepSampleStage` to generate representative samples
- call `RepSampleStage` from `BigQueryVisualizer.get_representative_sample`
- export new stage in `stages/__init__.py`
- document in README
- add test coverage for new stage
- fix circular import in `BaseStage`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b1a4049b88321bf6dc620eb28af8c