### PR TITLE
Add BQML diagnostics and local PDP

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,13 +13,13 @@
 
 | module | highlight |
 |--------|-----------|
-| `bigquery_visualizer.py` | 1-line connection ➜ 20+ plotting / analysis helpers (bar, scatter, histogram, violin, pie, sunburst, descriptive stats …) |
+| `bigquery_visualizer.py` | 1-line connection ➜ 20+ plotting / analysis helpers (bar, scatter, histogram, violin, pie, sunburst, descriptive stats, sample-based partial dependence …) |
 | `stages/` | Each `Stage` runs one slice of EDA (profiling, quality, univariate, …) and writes artefacts into a shared `AnalysisContext`. |
 | `pipeline.py` | Orchestrator that executes any list of stages: `Pipeline().run(viz)`. |
 | `analysis_context.py` | In-memory store for result tables & figures—later export to HTML / Markdown. |
 | cost guard | Dry-run every query; abort if bytes scanned > configurable limit (default 1 GB) and if `EXPLAIN` estimates the result exceeds `max_result_bytes` (default 2 GB). |
 | cache | DataFrames are cached per session only when their memory usage is below `cache_threshold_bytes` (default 100 MB). |
-| `feature_advice.py` | Auto-suggest encoding, scaling and interaction plans based on profiling results. |
+| `feature_advice.py` | Auto-suggest encoding, scaling and interaction plans and trains a quick BQML linear regression for diagnostics. |
 | `RepSampleStage` | Build representative samples via `TABLESAMPLE` or stratified sampling. |
 
 ---
@@ -96,6 +96,7 @@ The `FeatureAdviceStage` consumes earlier statistics to auto‑generate
 encoding, imputation and scaling suggestions, plus a list of possible
 interaction terms. These tables can guide feature engineering for a
 machine learning model.
+Running this stage requires the BigQuery ML API to be enabled.
 
 ## 🛠️ Configuration
 

--- a/tests/test_partial_dependence.py
+++ b/tests/test_partial_dependence.py
@@ -13,9 +13,10 @@ class DummyViz(BigQueryVisualizer):
         self.categorical_columns = []
         self._df = df
         self.auto_show = False
-    def _execute_query(self, q, use_cache=True):
-        if 'GROUP BY bin_id' in q:
-            return pd.DataFrame({'bin_id':[0,1],'avg_target':[15,45],'n':[3,2]})
+
+    def get_representative_sample(self, columns=None, max_bytes=None, refresh=False):
+        if columns:
+            return self._df[columns].copy()
         return self._df.copy()
 
 
@@ -23,5 +24,6 @@ def test_partial_dependence():
     df = pd.DataFrame({'feat':[1,2,3,4,5], 'target':[10,20,30,40,50]})
     viz = DummyViz(df)
     tbl, fig = viz.partial_dependence(feature='feat', target='target', bins=2)
-    assert not tbl.empty
+    assert list(tbl.columns) == ['bin_id', 'avg_target', 'n']
+    assert tbl['n'].sum() == len(df)
     assert fig is not None


### PR DESCRIPTION
## Summary
- extend FeatureAdviceStage with BigQuery ML linear regression metrics and weights
- compute partial dependence from representative sample instead of SQL
- adjust README to mention BQML requirement and new PDP behaviour
- update tests for new model queries and partial dependence logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b1cd71cd08321bf84364179bc9563