### PR TITLE
Introduce polars based sampling cache

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,8 @@ dependencies = [
     "numpy",
     "jinja2",
     "umap-learn",
+    "polars",
+    "pyarrow",
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ scikit-learn
 numpy
 jinja2
 umap-learn
+polars
+pyarrow

--- a/stages/core_stages.py
+++ b/stages/core_stages.py
@@ -269,7 +269,11 @@ class QualityStage(BaseStage):
         # IsolationForest on numeric sample
         sample_n = int(ctx.params.get("sample_rows", 10000))
         if viz.numeric_columns:
-            sample_df = viz.get_representative_sample(columns=viz.numeric_columns)
+            sample_df = (
+                viz.get_representative_sample(columns=viz.numeric_columns)
+                .collect()
+                .to_pandas()
+            )
             if len(sample_df) > sample_n:
                 sample_df = sample_df.sample(sample_n, random_state=42)
             if not sample_df.empty:
@@ -336,7 +340,11 @@ class BivariateStage(BaseStage):
 
             if ctx.params.get("lowess_plots"):
                 from itertools import combinations
-                df = viz.get_representative_sample(columns=num_cols[:5])
+                df = (
+                    viz.get_representative_sample(columns=num_cols[:5])
+                    .collect()
+                    .to_pandas()
+                )
                 for x, y in combinations(num_cols[:5], 2):
                     if df.empty:
                         break
@@ -348,7 +356,11 @@ class BivariateStage(BaseStage):
         numcat_results = []
         for num in viz.numeric_columns:
             for cat in viz.categorical_columns:
-                df_pair = viz.get_representative_sample(columns=[cat, num]).dropna()
+                df_pair = (
+                    viz.get_representative_sample(columns=[cat, num])
+                    .collect()
+                    .to_pandas()
+                ).dropna()
                 if len(df_pair) > sample_n:
                     df_pair = df_pair.sample(sample_n, random_state=42)
                 if df_pair.empty:
@@ -423,7 +435,11 @@ class MultivariateStage(BaseStage):
 
         # pull sample
         sample_n = int(ctx.params.get("sample_rows", 100_000))
-        df = viz.get_representative_sample(columns=num_cols).dropna()
+        df = (
+            viz.get_representative_sample(columns=num_cols)
+            .collect()
+            .to_pandas()
+        ).dropna()
         if len(df) > sample_n:
             df = df.sample(sample_n, random_state=42)
         if df.empty:

--- a/tests/test_bivariate_stage.py
+++ b/tests/test_bivariate_stage.py
@@ -3,6 +3,7 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
 
 
 import pandas as pd
+import polars as pl
 from bq_eda_toolkit.analysis_context import AnalysisContext
 from bq_eda_toolkit.stages.core_stages import BivariateStage
 
@@ -34,7 +35,7 @@ class DummyViz:
         df = self.rep_sample_df.copy()
         if columns:
             df = df[columns]
-        return df
+        return pl.from_pandas(df).lazy()
 
 def test_bivariate_stage_basic():
     ctx = AnalysisContext(params={'lowess_plots': True})

--- a/tests/test_histogram_kde.py
+++ b/tests/test_histogram_kde.py
@@ -3,6 +3,7 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
 
 
 import pandas as pd
+import polars as pl
 from bq_eda_toolkit.bigquery_visualizer import BigQueryVisualizer
 
 class DummyViz(BigQueryVisualizer):
@@ -24,7 +25,7 @@ class DummyViz(BigQueryVisualizer):
         return pd.DataFrame()
 
     def get_representative_sample(self, columns=None, max_bytes=None, refresh=False):
-        return pd.DataFrame({'num':[1,2,2,3,4,5]})
+        return pl.DataFrame({'num':[1,2,2,3,4,5]}).lazy()
 
 def test_histogram_with_kde():
     viz = DummyViz()

--- a/tests/test_missingness.py
+++ b/tests/test_missingness.py
@@ -3,6 +3,7 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
 
 
 import pandas as pd
+import polars as pl
 from bq_eda_toolkit.bigquery_visualizer import BigQueryVisualizer
 
 class DummyViz(BigQueryVisualizer):
@@ -20,7 +21,7 @@ class DummyViz(BigQueryVisualizer):
         df = self.rep_sample_df.copy()
         if columns:
             df = df[columns]
-        return df
+        return pl.from_pandas(df).lazy()
 
 
 def test_missingness_functions():

--- a/tests/test_multivariate_stage.py
+++ b/tests/test_multivariate_stage.py
@@ -3,6 +3,7 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
 
 
 import pandas as pd
+import polars as pl
 from bq_eda_toolkit.analysis_context import AnalysisContext
 from bq_eda_toolkit.stages.core_stages import MultivariateStage
 from bq_eda_toolkit.bigquery_visualizer import BigQueryVisualizer
@@ -32,7 +33,7 @@ class DummyViz(BigQueryVisualizer):
         df = self.rep_sample_df.copy()
         if columns:
             df = df[columns]
-        return df
+        return pl.from_pandas(df).lazy()
 
 
 def test_multivariate_stage_projections():

--- a/tests/test_partial_dependence.py
+++ b/tests/test_partial_dependence.py
@@ -3,6 +3,7 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
 
 
 import pandas as pd
+import polars as pl
 from bq_eda_toolkit.bigquery_visualizer import BigQueryVisualizer
 
 class DummyViz(BigQueryVisualizer):
@@ -16,8 +17,8 @@ class DummyViz(BigQueryVisualizer):
 
     def get_representative_sample(self, columns=None, max_bytes=None, refresh=False):
         if columns:
-            return self._df[columns].copy()
-        return self._df.copy()
+            return pl.from_pandas(self._df[columns].copy()).lazy()
+        return pl.from_pandas(self._df.copy()).lazy()
 
 
 def test_partial_dependence():

--- a/tests/test_quality_stage.py
+++ b/tests/test_quality_stage.py
@@ -3,6 +3,7 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
 
 
 import pandas as pd
+import polars as pl
 import seaborn as sns
 import matplotlib.pyplot as plt
 from bq_eda_toolkit.analysis_context import AnalysisContext
@@ -38,7 +39,7 @@ class DummyViz:
         df = self.rep_sample_df.copy()
         if columns:
             df = df[columns]
-        return df
+        return pl.from_pandas(df).lazy()
 
     def missingness_map(self, columns=None, sample_rows=100000):
         df = pd.DataFrame({'a':[1,2], 'num1':[1,2], 'cat1':['x','y']})

--- a/tests/test_univariate_stage.py
+++ b/tests/test_univariate_stage.py
@@ -3,6 +3,7 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
 
 
 import pandas as pd
+import polars as pl
 from bq_eda_toolkit.analysis_context import AnalysisContext
 from bq_eda_toolkit.stages.core_stages import UnivariateStage
 from bq_eda_toolkit.bigquery_visualizer import BigQueryVisualizer
@@ -38,7 +39,7 @@ class DummyViz(BigQueryVisualizer):
         df = pd.DataFrame({'num1':[1,2,3,4], 'num2':[10,20,30,40]})
         if columns:
             df = df[columns]
-        return df
+        return pl.from_pandas(df).lazy()
 
 
 def test_univariate_stage_kde_histograms():


### PR DESCRIPTION
## Summary
- keep representative sample on disk using polars lazy frames
- auto-load lazy samples on Visualizer init and provide cache clearing utilities
- ensure downstream functions convert samples from LazyFrame to pandas
- update tests for LazyFrame workflow and update stages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c5ea5fd2883219f1aba49e10adc70