### PR TITLE
Add percentage hover info to histograms

### DIFF
--- a/tests/test_histogram_kde.py
+++ b/tests/test_histogram_kde.py
@@ -32,3 +32,5 @@ def test_histogram_with_kde():
     _, fig = viz.plot_histogram(numeric_column='num', kde=True, bins=5)
     assert fig is not None
     assert len(fig.data) > 1
+    assert hasattr(fig.data[0], 'customdata')
+    assert 'Share' in fig.data[0].hovertemplate


### PR DESCRIPTION
## Summary
- show percentages in histogram hover info with new `show_pct` option
- test histogram hover includes percentage share

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c910c84088321878a9d4e5e8ded90