### PR TITLE
Add dataset comparison stage

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -73,6 +73,12 @@ row_count_df = execute_query_with_guard(
     viz.client,
     "SELECT COUNT(*) AS n FROM dataset.table",
 )
+
+# Use DatasetComparisonStage to check for distribution drift between tables
+# results are stored under "comparison.drift_tests"
+other = BigQueryVisualizer(project_id="my-project", table_id="dataset.previous")
+ctx = Pipeline(stages=[DatasetComparisonStage(other)]).run(viz)
+print(ctx.get_table("comparison.drift_tests"))
 ```
 
 Visualisation functions return Plotly or Matplotlib objects. They do not call

--- a/stages/__init__.py
+++ b/stages/__init__.py
@@ -9,6 +9,7 @@ from .core_stages import (
     TargetStage,
     RepSampleStage,
 )
+from .comparison import DatasetComparisonStage
 
 __all__ = [
     "ProfilingStage",
@@ -18,5 +19,6 @@ __all__ = [
     "MultivariateStage",
     "TargetStage",
     "RepSampleStage",
+    "DatasetComparisonStage",
 ]
 

--- a/stages/comparison.py
+++ b/stages/comparison.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+import pandas as pd
+from typing import TYPE_CHECKING
+from .base import BaseStage
+from ..analysis_context import AnalysisContext
+
+if TYPE_CHECKING:
+    from ..bigquery_visualizer import BigQueryVisualizer
+
+
+class DatasetComparisonStage(BaseStage):
+    """Run statistical drift tests between two datasets."""
+
+    id = "comparison"
+
+    def __init__(self, other_viz: 'BigQueryVisualizer', sample_rows: int = 1000, alpha: float = 0.05) -> None:
+        self.other_viz = other_viz
+        self.sample_rows = sample_rows
+        self.alpha = alpha
+
+    def run(self, viz: 'BigQueryVisualizer', ctx: AnalysisContext) -> pd.DataFrame:
+        df = viz.compare_to(self.other_viz, sample_rows=self.sample_rows, alpha=self.alpha)
+        ctx.add_table(self.key("drift_tests"), df)
+        return df

--- a/tests/test_dataset_comparison_stage.py
+++ b/tests/test_dataset_comparison_stage.py
@@ -1,0 +1,46 @@
+import os, sys
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+
+import pandas as pd
+from bq_eda_toolkit.analysis_context import AnalysisContext
+from bq_eda_toolkit.stages.comparison import DatasetComparisonStage
+from bq_eda_toolkit.bigquery_visualizer import BigQueryVisualizer
+
+class DummyViz(BigQueryVisualizer):
+    def __init__(self, df):
+        self.df = df.reset_index(drop=True)
+        self.full_table_path = 'x'
+        self.columns = list(df.columns)
+        self.numeric_columns = [c for c in df.columns if pd.api.types.is_numeric_dtype(df[c])]
+        self.categorical_columns = [c for c in df.columns if c not in self.numeric_columns]
+        self.string_columns = self.categorical_columns.copy()
+        self.boolean_columns = []
+        self.datetime_columns = []
+        self.complex_columns = []
+        self.geographic_columns = []
+        self.auto_show = False
+
+    def fetch_sample(self, n, *, where=None):
+        return self.df.sample(min(n, len(self.df)), random_state=42)
+
+
+def test_dataset_comparison_stage_detects_drift():
+    df1 = pd.DataFrame({
+        'num': list(range(100)) + list(range(100)),
+        'cat': ['A'] * 150 + ['B'] * 50,
+    })
+    df2 = pd.DataFrame({
+        'num': list(range(50, 150)) + list(range(50, 150)),
+        'cat': ['A'] * 40 + ['B'] * 160,
+    })
+
+    viz1 = DummyViz(df1)
+    viz2 = DummyViz(df2)
+
+    ctx = AnalysisContext()
+    DatasetComparisonStage(viz2, sample_rows=50).run(viz1, ctx)
+
+    drift = ctx.get_table('comparison.drift_tests')
+    assert drift is not None
+    assert not drift.empty
+    assert any(drift['drift'])


### PR DESCRIPTION
## Summary
- compare two tables with `BigQueryVisualizer.compare_to`
- new `DatasetComparisonStage` stage for drift detection
- expose the new stage
- document dataset comparison usage
- test comparison functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e06ecede483219ad298a0ed112554