### PR TITLE
Add validation stage producing Great Expectations suite

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "umap-learn",
     "polars",
     "pyarrow",
+    "great_expectations",
 ]
 
 [project.urls]

--- a/readme.md
+++ b/readme.md
@@ -131,6 +131,24 @@ ctx = pipe.run(viz)
 Results are shared via the `AnalysisContext`, so custom stages can consume or
 produce tables just like the built‑in ones.
 
+### Validation with Great Expectations
+
+`ValidationStage` transforms profiling and quality tables into a
+[Great Expectations](https://greatexpectations.io/) `ExpectationSuite`.
+Include this stage after `QualityStage` to generate a suite:
+
+```python
+from bq_eda_toolkit.stages import ProfilingStage, QualityStage, ValidationStage
+from bq_eda_toolkit.pipeline import Pipeline
+
+pipe = Pipeline(stages=[ProfilingStage(), QualityStage(), ValidationStage()])
+ctx = pipe.run(viz)
+suite_json = ctx.get_table("validation.expectation_suite")
+```
+
+The JSON dict can be saved and later loaded with
+`ExpectationSuite.from_json_dict()` to validate new data.
+
 ## 🛠️ Configuration
 
 BigQuery credentials can be supplied either via the `credentials_path` argument or by setting the `GOOGLE_APPLICATION_CREDENTIALS` environment variable. The visualizer also exposes query guard parameters:

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ jinja2
 umap-learn
 polars
 pyarrow
+great_expectations

--- a/stages/__init__.py
+++ b/stages/__init__.py
@@ -10,6 +10,7 @@ from .core_stages import (
     RepSampleStage,
 )
 from .comparison import DatasetComparisonStage
+from .validation import ValidationStage
 
 __all__ = [
     "ProfilingStage",
@@ -20,5 +21,6 @@ __all__ = [
     "TargetStage",
     "RepSampleStage",
     "DatasetComparisonStage",
+    "ValidationStage",
 ]
 

--- a/stages/validation.py
+++ b/stages/validation.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .base import BaseStage
+from ..analysis_context import AnalysisContext
+from ..validation import build_expectation_suite
+
+if TYPE_CHECKING:  # pragma: no cover
+    from ..bigquery_visualizer import BigQueryVisualizer
+
+
+class ValidationStage(BaseStage):
+    """Generate a Great Expectations suite from prior stage outputs."""
+
+    id = "validation"
+
+    def run(self, viz: 'BigQueryVisualizer', ctx: AnalysisContext):
+        suite = build_expectation_suite(viz, ctx)
+        ctx.tables[self.key("expectation_suite")] = suite.to_json_dict()
+        return suite

--- a/tests/test_validation_stage.py
+++ b/tests/test_validation_stage.py
@@ -1,0 +1,50 @@
+import os, sys
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+
+import pandas as pd
+from bq_eda_toolkit.analysis_context import AnalysisContext
+from bq_eda_toolkit.stages.validation import ValidationStage
+
+class DummyViz:
+    def __init__(self):
+        self.schema_df = pd.DataFrame({
+            'column_name': ['id', 'name', 'created'],
+            'data_type': ['INT64', 'STRING', 'TIMESTAMP'],
+            'category': ['numeric', 'string', 'datetime'],
+        })
+        self.columns = ['id', 'name', 'created']
+
+
+def test_validation_stage_builds_suite():
+    ctx = AnalysisContext()
+    viz = DummyViz()
+    # schema info
+    ctx.add_table('profiling.schema_overview', viz.schema_df)
+
+    # quality tables
+    missing = pd.DataFrame({
+        'column': ['id', 'name', 'created'],
+        'non_nulls': [10, 9, 10],
+        'pct': [100.0, 90.0, 100.0],
+        'missing_pct': [0.0, 10.0, 0.0],
+    })
+    ctx.add_table('quality.missing_pct', missing)
+
+    uniq = pd.DataFrame({
+        'column': ['id', 'name', 'created'],
+        'unique_count': [10, 9, 10],
+        'unique_ratio': [100.0, 90.0, 100.0],
+        'constant': [False, False, False],
+        'quasi_constant': [False, False, False],
+    })
+    ctx.add_table('quality.unique_ratio', uniq)
+
+    ValidationStage().run(viz, ctx)
+    suite_dict = ctx.get_table('validation.expectation_suite')
+
+    assert isinstance(suite_dict, dict)
+    expectations = suite_dict.get('expectations', [])
+    # ensure each column appears at least once
+    cols_in_suite = {e['kwargs']['column'] for e in expectations}
+    for col in viz.schema_df['column_name']:
+        assert col in cols_in_suite

--- a/validation.py
+++ b/validation.py
@@ -1,0 +1,60 @@
+"""Utilities for generating Great Expectations suites from EDA results."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pandas as pd
+from great_expectations.core import ExpectationSuite
+from great_expectations.expectations.expectation_configuration import (
+    ExpectationConfiguration,
+)
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .bigquery_visualizer import BigQueryVisualizer
+    from .analysis_context import AnalysisContext
+
+
+def build_expectation_suite(viz: 'BigQueryVisualizer', ctx: 'AnalysisContext') -> ExpectationSuite:
+    """Create a basic :class:`ExpectationSuite` from profiling results."""
+    schema_df: pd.DataFrame | None = ctx.get_table('profiling.schema_overview')
+    if schema_df is None and hasattr(viz, 'schema_df'):
+        schema_df = viz.schema_df
+    if schema_df is None:
+        raise ValueError('Schema information not found in context.')
+
+    missing_df: pd.DataFrame | None = ctx.get_table('quality.missing_pct')
+    uniq_df: pd.DataFrame | None = ctx.get_table('quality.unique_ratio')
+
+    suite = ExpectationSuite('generated_suite')
+
+    for _, row in schema_df.iterrows():
+        col = row['column_name']
+        dtype = row['data_type']
+        suite.add_expectation_configuration(
+            ExpectationConfiguration(
+                "expect_column_values_to_be_of_type",
+                {"column": col, "type_": dtype},
+            )
+        )
+
+        if missing_df is not None:
+            mrow = missing_df[missing_df['column'] == col]
+            if not mrow.empty and float(mrow['missing_pct'].iloc[0]) == 0:
+                suite.add_expectation_configuration(
+                    ExpectationConfiguration(
+                        "expect_column_values_to_not_be_null",
+                        {"column": col},
+                    )
+                )
+
+        if uniq_df is not None:
+            urow = uniq_df[uniq_df['column'] == col]
+            if not urow.empty and float(urow['unique_ratio'].iloc[0]) == 100.0:
+                suite.add_expectation_configuration(
+                    ExpectationConfiguration(
+                        "expect_column_values_to_be_unique",
+                        {"column": col},
+                    )
+                )
+
+    return suite


### PR DESCRIPTION
## Summary
- add `great_expectations` dependency
- implement `build_expectation_suite` utility
- create `ValidationStage` to generate an expectation suite
- export the new stage
- test the validation stage
- document Great Expectations integration

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e0a5399288321a6886cacf63db739