### PR TITLE
Add numeric covariance matrix

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -74,6 +74,10 @@ row_count_df = execute_query_with_guard(
     "SELECT COUNT(*) AS n FROM dataset.table",
 )
 
+# compute pairwise covariances
+cov = viz.numeric_covariances(["feature_a", "feature_b"])
+print(cov)
+
 # Use DatasetComparisonStage to check for distribution drift between tables
 # results are stored under "comparison.drift_tests"
 other = BigQueryVisualizer(project_id="my-project", table_id="dataset.previous")

--- a/stages/core_stages.py
+++ b/stages/core_stages.py
@@ -338,6 +338,10 @@ class BivariateStage(BaseStage):
             if not spear.empty:
                 ctx.add_table(self.key("spearman_corr"), spear)
 
+            cov = viz.numeric_covariances(num_cols)
+            if not cov.empty:
+                ctx.add_table(self.key("covariance"), cov)
+
             if ctx.params.get("lowess_plots"):
                 from itertools import combinations
                 df = (

--- a/tests/test_bivariate_stage.py
+++ b/tests/test_bivariate_stage.py
@@ -24,6 +24,9 @@ class DummyViz:
     def numeric_correlations(self, columns, method='pearson'):
         return pd.DataFrame([[1.0, 0.5],[0.5,1.0]], index=columns, columns=columns)
 
+    def numeric_covariances(self, columns, sample=False):
+        return pd.DataFrame([[0.0, 0.3],[0.3,0.0]], index=columns, columns=columns)
+
     def get_representative_sample(self, columns=None, max_bytes=None, refresh=False):
         if self.rep_sample_df is None or refresh:
             self.rep_sample_df = pd.DataFrame({

--- a/tests/test_numeric_covariances.py
+++ b/tests/test_numeric_covariances.py
@@ -1,0 +1,27 @@
+import os, sys
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+
+import pandas as pd
+from bq_eda_toolkit.bigquery_visualizer import BigQueryVisualizer
+
+class DummyViz(BigQueryVisualizer):
+    def __init__(self):
+        self.full_table_path = 'x'
+        self.columns = ['a', 'b']
+        self.numeric_columns = ['a', 'b']
+        self.categorical_columns = []
+        self.auto_show = False
+
+    def _execute_query(self, q, use_cache=True):
+        if 'COVAR_' in q:
+            return pd.DataFrame({'c1':['a'], 'c2':['b'], 'cov':[2.5]})
+        return pd.DataFrame()
+
+    def get_representative_sample(self, columns=None, max_bytes=None, refresh=False):
+        return pd.DataFrame({'a':[1,2], 'b':[3,4]})
+
+def test_numeric_covariances():
+    viz = DummyViz()
+    mat = viz.numeric_covariances(['a','b'])
+    assert mat.loc['a','b'] == 2.5
+    assert mat.loc['b','a'] == 2.5


### PR DESCRIPTION
## Summary
- implement `numeric_covariances` to compute pairwise COVAR_POP/SAMP
- expose covariance matrix via `BivariateStage`
- document covariance example usage in README
- add unit test for numeric covariance computation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883d0bbd3ec83218e8acea5326497bf